### PR TITLE
clique stage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher 0.3.0",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aes-gcm-siv"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1_der"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +314,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,12 +339,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c374dda1ed3e7d8f0d9ba58715f924862c63eae6849c92d3a18e7fbde9e2794"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-net"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "signal-hook",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba50e24d9ee0a8950d3d03fc6d0dd10aa14b5de3b101949b4e160f7fee7c723"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-io",
+ "futures-util",
+ "pin-utils",
+ "socket2",
+ "trust-dns-resolver",
 ]
 
 [[package]]
@@ -338,6 +512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +527,25 @@ dependencies = [
  "quote 1.0.18",
  "syn 1.0.98",
 ]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -434,6 +633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +649,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64ct"
@@ -510,6 +721,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "blake3"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +788,20 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+]
 
 [[package]]
 name = "borsh"
@@ -830,6 +1064,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chacha20"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.3.0",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher 0.3.0",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +1202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7bef69dc86e3c610e4e7aed41035e2a7ed12e72dd7530f61327a6579a4390b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1300,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "core_affinity"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,12 +1386,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
 ]
 
 [[package]]
@@ -1166,6 +1442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1466,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix",
+ "nix 0.25.0",
  "winapi 0.3.9",
 ]
 
@@ -1194,6 +1480,20 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.5.1",
  "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.0.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bc65846be335cb20f4e52d49a437b773a2c1fdb42b19fc84e79e6f6771536f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fiat-crypto",
+ "packed_simd_2",
+ "platforms",
  "subtle",
  "zeroize",
 ]
@@ -1225,6 +1525,26 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn 1.0.98",
+]
 
 [[package]]
 name = "der"
@@ -1396,6 +1716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00704156a7de8df8da0911424e30c2049957b0a714542a44e05fe693dd85313"
+
+[[package]]
 name = "eager"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,7 +1742,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "ed25519",
  "rand 0.7.3",
  "serde",
@@ -1467,6 +1793,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1609,6 +1947,12 @@ name = "feature-probe"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
 
 [[package]]
 name = "filedescriptor"
@@ -1757,6 +2101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +2124,17 @@ dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
+dependencies = [
+ "futures-io",
+ "rustls 0.20.7",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -1778,6 +2148,12 @@ name = "futures-task"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1903,6 +2279,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1919,6 +2305,18 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c4a8d6391675c6b2ee1a6c8d06e8e2d03605c44cec1270675985a4c2a5500b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2053,6 +2451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
 name = "hidapi"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2501,17 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.6",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2195,7 +2610,7 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "tokio",
  "tokio-rustls 0.23.3",
 ]
@@ -2267,6 +2682,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
+name = "if-addrs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7abdbb86e485125dad06c2691e1e393bf3b08c7b743b43aa162a00fd39062e"
+dependencies = [
+ "async-io",
+ "core-foundation",
+ "fnv",
+ "futures 0.3.24",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "rtnetlink",
+ "smol",
+ "system-configuration",
+ "windows",
+]
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,6 +2777,18 @@ name = "io-lifetimes"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
+name = "ipconfig"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd302af1b90f2463a98fa5ad469fc212c8e3175a41c3068601bfa2727591c5be"
+dependencies = [
+ "socket2",
+ "widestring",
+ "winapi 0.3.9",
+ "winreg",
+]
 
 [[package]]
 name = "ipnet"
@@ -2527,6 +2983,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,9 +3021,303 @@ dependencies = [
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "libp2p"
+version = "0.51.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "bytes",
+ "futures 0.3.24",
+ "futures-timer",
+ "getrandom 0.2.3",
+ "instant",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-ping",
+ "libp2p-quic",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-yamux",
+ "multiaddr",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.39.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.24",
+ "futures-timer",
+ "instant",
+ "log",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "prost 0.11.0",
+ "prost-build 0.11.0",
+ "rand 0.8.5",
+ "rw-stream-sink",
+ "sha2 0.10.5",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.39.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "async-std-resolver",
+ "futures 0.3.24",
+ "libp2p-core",
+ "log",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.44.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.20.0",
+ "byteorder",
+ "bytes",
+ "fnv",
+ "futures 0.3.24",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "prost 0.11.0",
+ "prost-build 0.11.0",
+ "prost-codec",
+ "rand 0.8.5",
+ "regex",
+ "sha2 0.10.5",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "wasm-timer",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.42.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "asynchronous-codec",
+ "futures 0.3.24",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "lru 0.8.1",
+ "prost 0.11.0",
+ "prost-build 0.11.0",
+ "prost-codec",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.43.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "async-io",
+ "data-encoding",
+ "futures 0.3.24",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "rand 0.8.5",
+ "smallvec",
+ "socket2",
+ "trust-dns-proto",
+ "void",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.12.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "libp2p-core",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-ping",
+ "libp2p-swarm",
+ "prometheus-client",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.42.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "bytes",
+ "curve25519-dalek 3.2.1",
+ "futures 0.3.24",
+ "libp2p-core",
+ "log",
+ "once_cell",
+ "prost 0.11.0",
+ "prost-build 0.11.0",
+ "rand 0.8.5",
+ "sha2 0.10.5",
+ "snow",
+ "static_assertions",
+ "thiserror",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.42.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "futures 0.3.24",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm",
+ "log",
+ "rand 0.8.5",
+ "void",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.7.0-alpha.2"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "async-std",
+ "bytes",
+ "futures 0.3.24",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-tls",
+ "log",
+ "parking_lot 0.12.1",
+ "quinn-proto 0.9.2",
+ "rand 0.8.5",
+ "rustls 0.20.7",
+ "thiserror",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.42.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "async-std",
+ "either",
+ "fnv",
+ "futures 0.3.24",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-swarm-derive",
+ "log",
+ "pin-project",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.31.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "heck 0.4.0",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.39.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "async-io",
+ "futures 0.3.24",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "log",
+ "socket2",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.1.0-alpha.2"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "futures 0.3.24",
+ "futures-rustls",
+ "libp2p-core",
+ "rcgen",
+ "ring",
+ "rustls 0.20.7",
+ "thiserror",
+ "webpki 0.22.0",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.43.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "futures 0.3.24",
+ "libp2p-core",
+ "log",
+ "parking_lot 0.12.1",
+ "thiserror",
+ "yamux",
+]
 
 [[package]]
 name = "librocksdb-sys"
@@ -2661,6 +3420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
+ "value-bag",
 ]
 
 [[package]]
@@ -2670,6 +3430,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+dependencies = [
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -2703,6 +3481,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -2823,10 +3607,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b53e0cc5907a5c216ba6584bf74be8ab47d6d6289f72793b2dddbf15dc3bf8c"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "multibase",
+ "multihash",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
+dependencies = [
+ "base-x",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835d6ff01d610179fbce3de1694d007e500bf33a7f29689838941d6bf783ae40"
+dependencies = [
+ "core2",
+ "digest 0.10.3",
+ "multihash-derive",
+ "sha2 0.10.5",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+ "synstructure",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "multistream-select"
+version = "0.12.1"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "bytes",
+ "futures 0.3.24",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint",
+]
 
 [[package]]
 name = "native-tls"
@@ -2858,6 +3711,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "libc",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ea4302b9759a7a88242299225ea3688e63c85ea136371bb6cf94fd674efaab"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "byteorder",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+dependencies = [
+ "bytes",
+ "futures 0.3.24",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
+dependencies = [
+ "async-io",
+ "bytes",
+ "futures 0.3.24",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +3800,12 @@ dependencies = [
  "memoffset",
  "pin-utils",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3053,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -3177,6 +4113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libm 0.1.4",
+]
+
+[[package]]
 name = "parity-tokio-ipc"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3189,6 +4135,12 @@ dependencies = [
  "tokio",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -3363,18 +4315,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -3415,6 +4367,37 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "platforms"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
+
+[[package]]
+name = "polling"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "polyval"
@@ -3542,6 +4525,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
+dependencies = [
+ "dtoa",
+ "itoa 1.0.1",
+ "parking_lot 0.12.1",
+ "prometheus-client-derive-text-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-text-encode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
+dependencies = [
+ "proc-macro2 1.0.41",
+ "quote 1.0.18",
+ "syn 1.0.98",
+]
+
+[[package]]
 name = "proptest"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +4625,18 @@ dependencies = [
  "regex",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-codec"
+version = "0.3.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "prost 0.11.0",
+ "thiserror",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -3715,9 +4733,9 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "fxhash",
- "quinn-proto",
+ "quinn-proto 0.8.4",
  "quinn-udp",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -3734,9 +4752,27 @@ dependencies = [
  "fxhash",
  "rand 0.8.5",
  "ring",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "rustls-native-certs",
  "rustls-pemfile 0.2.1",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.7",
  "slab",
  "thiserror",
  "tinyvec",
@@ -3752,7 +4788,7 @@ checksum = "9f832d8958db3e84d2ec93b5eb2272b45aa23cf7f8fe6e79f578896f4e6c231b"
 dependencies = [
  "futures-util",
  "libc",
- "quinn-proto",
+ "quinn-proto 0.8.4",
  "socket2",
  "tokio",
  "tracing",
@@ -3985,8 +5021,8 @@ checksum = "7263373d500d4d4f505d43a2a662d475a894aa94503a1ee28e9188b5f3960d4f"
 dependencies = [
  "cc",
  "libc",
- "libm",
- "lru",
+ "libm 0.2.1",
+ "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
  "spin 0.9.2",
@@ -4050,7 +5086,7 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
@@ -4066,6 +5102,16 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -4101,6 +5147,21 @@ checksum = "26b763cb66df1c928432cc35053f8bd4cec3335d8559fc16010017d16b3c1680"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
+dependencies = [
+ "async-global-executor",
+ "futures 0.3.24",
+ "log",
+ "netlink-packet-route",
+ "netlink-proto",
+ "nix 0.24.3",
+ "thiserror",
 ]
 
 [[package]]
@@ -4171,9 +5232,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
@@ -4227,6 +5288,16 @@ dependencies = [
  "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.3.0"
+source = "git+https://github.com/mschneider/rust-libp2p/?branch=solana-compat#67bf9e84297e8c42eaab3e7b0101fc68a8a31622"
+dependencies = [
+ "futures 0.3.24",
+ "pin-project",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4604,6 +5675,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
+name = "smol"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "smpl_jwt"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4617,6 +5705,23 @@ dependencies = [
  "serde_json",
  "simpl",
  "time 0.3.9",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek 4.0.0-pre.5",
+ "rand_core 0.6.3",
+ "ring",
+ "rustc_version 0.4.0",
+ "sha2 0.10.5",
+ "subtle",
 ]
 
 [[package]]
@@ -5188,11 +6293,14 @@ dependencies = [
  "eager",
  "etcd-client",
  "fs_extra",
+ "futures 0.3.24",
+ "futures-lite",
  "histogram",
  "itertools",
  "lazy_static",
+ "libp2p",
  "log",
- "lru",
+ "lru 0.7.8",
  "matches",
  "min-max-heap",
  "num_enum",
@@ -5505,7 +6613,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "log",
- "lru",
+ "lru 0.7.8",
  "matches",
  "num-traits",
  "num_cpus",
@@ -5556,7 +6664,7 @@ dependencies = [
  "dirs-next",
  "indicatif",
  "lazy_static",
- "nix",
+ "nix 0.25.0",
  "reqwest",
  "scopeguard",
  "semver 1.0.14",
@@ -5610,7 +6718,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "lru",
+ "lru 0.7.8",
  "matches",
  "num_cpus",
  "num_enum",
@@ -5829,7 +6937,7 @@ dependencies = [
  "clap 3.1.8",
  "crossbeam-channel",
  "log",
- "nix",
+ "nix 0.25.0",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -5859,7 +6967,7 @@ dependencies = [
  "bincode",
  "bv",
  "caps",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "dlopen",
  "dlopen_derive",
  "fnv",
@@ -5867,7 +6975,7 @@ dependencies = [
  "libc",
  "log",
  "matches",
- "nix",
+ "nix 0.25.0",
  "rand 0.7.3",
  "rayon",
  "serde",
@@ -5934,7 +7042,7 @@ dependencies = [
  "cc",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "getrandom 0.2.3",
  "itertools",
  "js-sys",
@@ -5987,7 +7095,7 @@ dependencies = [
  "cc",
  "console_error_panic_hook",
  "console_log",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "getrandom 0.2.3",
  "itertools",
  "js-sys",
@@ -6108,9 +7216,9 @@ dependencies = [
  "lazy_static",
  "log",
  "quinn",
- "quinn-proto",
+ "quinn-proto 0.8.4",
  "quinn-udp",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "solana-logger 1.15.0",
  "solana-measure",
  "solana-metrics",
@@ -6324,7 +7432,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "lru",
+ "lru 0.7.8",
  "lz4",
  "memmap2",
  "num-derive",
@@ -6433,7 +7541,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "chrono",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "derivation-path",
  "digest 0.10.3",
  "ed25519-dalek",
@@ -6617,16 +7725,16 @@ dependencies = [
  "itertools",
  "libc",
  "log",
- "nix",
+ "nix 0.25.0",
  "pem",
  "percentage",
  "pkcs8",
  "quinn",
- "quinn-proto",
+ "quinn-proto 0.8.4",
  "quinn-udp",
  "rand 0.7.3",
  "rcgen",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "solana-logger 1.15.0",
  "solana-metrics",
  "solana-perf",
@@ -6643,7 +7751,7 @@ dependencies = [
  "clap 2.33.3",
  "libc",
  "log",
- "nix",
+ "nix 0.25.0",
  "solana-logger 1.15.0",
  "solana-version",
  "sysctl",
@@ -6959,7 +8067,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "cipher 0.4.3",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "getrandom 0.1.16",
  "itertools",
  "lazy_static",
@@ -6988,7 +8096,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "cipher 0.4.3",
- "curve25519-dalek",
+ "curve25519-dalek 3.2.1",
  "getrandom 0.1.16",
  "itertools",
  "lazy_static",
@@ -7249,6 +8357,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75182f12f490e953596550b65ee31bda7c8e043d9386174b353bda50838c3fd"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "systemstat"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7386,18 +8515,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -7570,7 +8699,7 @@ version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
 dependencies = [
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -7610,7 +8739,7 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "tokio",
  "tokio-rustls 0.23.3",
  "tungstenite",
@@ -7801,9 +8930,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -7814,9 +8943,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2 1.0.41",
  "quote 1.0.18",
@@ -7825,11 +8954,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
- "lazy_static",
+ "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -7872,6 +9002,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de5f738ceab88e2491a94ddc33c3feeadfa95fedc60363ef110845df12f3878"
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.2.3",
+ "ipnet",
+ "lazy_static",
+ "rand 0.8.5",
+ "smallvec",
+ "socket2",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot 0.12.1",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tracing",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7890,7 +9065,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.20.6",
+ "rustls 0.20.7",
  "sha-1 0.10.0",
  "thiserror",
  "url 2.2.2",
@@ -8000,6 +9175,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
+name = "unsigned-varint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8061,6 +9246,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8092,6 +9293,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -8193,6 +9400,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures 0.3.24",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8232,6 +9454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8241,6 +9472,12 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"
@@ -8286,6 +9523,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8312,6 +9562,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8319,9 +9590,21 @@ checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8331,9 +9614,21 @@ checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8343,9 +9638,21 @@ checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8355,9 +9662,27 @@ checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8367,9 +9692,21 @@ checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "winreg"
@@ -8378,6 +9715,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+dependencies = [
+ "curve25519-dalek 3.2.1",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -8414,6 +9762,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yamux"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
+dependencies = [
+ "futures 0.3.24",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "static_assertions",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,9 +24,12 @@ dashmap = { version = "4.0.2", features = ["rayon", "raw-api"] }
 eager = "0.1.0"
 etcd-client = { version = "0.8.1", features = ["tls"] }
 fs_extra = "1.2.0"
+futures = "0.3.1"
+futures-lite = "1.12.0"
 histogram = "0.6.9"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
+libp2p = { git = "https://github.com/mschneider/rust-libp2p/", branch = "solana-compat", features=["async-std", "gossipsub", "identify", "macros", "noise", "ping", "tcp", "yamux"] }
 log = "0.4.17"
 lru = "0.7.7"
 min-max-heap = "1.3.0"

--- a/core/benches/cluster_nodes.rs
+++ b/core/benches/cluster_nodes.rs
@@ -25,7 +25,7 @@ fn make_cluster_nodes<R: Rng>(
     unstaked_ratio: Option<(u32, u32)>,
 ) -> (Vec<ContactInfo>, ClusterNodes<RetransmitStage>) {
     let (nodes, stakes, cluster_info) = make_test_cluster(rng, 5_000, unstaked_ratio);
-    let cluster_nodes = new_cluster_nodes::<RetransmitStage>(&cluster_info, &stakes);
+    let cluster_nodes = new_cluster_nodes::<RetransmitStage>(cluster_info.id(), &stakes);
     (nodes, cluster_nodes)
 }
 

--- a/core/src/clique_stage.rs
+++ b/core/src/clique_stage.rs
@@ -1,0 +1,513 @@
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    convert::TryFrom,
+    hash::{Hash, Hasher},
+    net::{UdpSocket, SocketAddr},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+    task::{Context, Poll},
+    thread::{Builder, JoinHandle, self},
+    time::{Duration, Instant}, iter::{repeat, once},
+};
+
+use crossbeam_channel::Receiver;
+use futures::task::noop_waker;
+use futures_lite::stream::StreamExt;
+use itertools::{Itertools, izip};
+use libp2p::{
+    core, gossipsub, identify, identity, noise, ping, swarm::NetworkBehaviour, swarm::SwarmEvent,
+    tcp, yamux, Multiaddr, PeerId, Swarm, Transport, multiaddr::Protocol,
+};
+use lru::LruCache;
+use rayon::{ThreadPoolBuilder, prelude::{IntoParallelIterator, ParallelIterator}};
+use solana_gossip::legacy_contact_info::LegacyContactInfo;
+use solana_ledger::{shred::{ShredId, layout::get_shred_id}};
+use solana_measure::measure::Measure;
+use solana_rayon_threadlimit::get_thread_count;
+use solana_sdk::{pubkey::Pubkey, signer::Signer};
+use solana_streamer::{socket::SocketAddrSpace, sendmmsg::{SendPktsError, multi_target_send}};
+
+use crate::{cluster_nodes::ClusterNodes, packet_hasher::PacketHasher, retransmit_stage::{maybe_reset_shreds_received_cache, should_skip_retransmit}};
+
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(1);
+const DATA_PLANE_FANOUT: usize = 8;
+const DEFAULT_LRU_SIZE: usize = 10_000;
+// Minimum number of shreds to use rayon parallel iterators.
+const PAR_ITER_MIN_NUM_SHREDS: usize = 2;
+const METRICS_SUBMIT_CADENCE: Duration = Duration::from_secs(2);
+const GOSSIP_HEARTBEAT_CADENCE: Duration = Duration::from_secs(10);
+ // allow for at least a second heartbeat message to arrive
+const CLIQUE_WARMUP_SLOTS: u64 = 30;
+ // allow for at least three heartbeat messages to be missed
+const CLIQUE_TIMEOUT_SLOTS: u64 = 70;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+enum CliqueGossipMessage {
+    Heartbeat(CliqueHeartbeatMessage)
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+struct CliqueHeartbeatMessage {
+    boot_slot: u64,
+    current_slot: u64,
+    shred_inbound: SocketAddr,
+}
+
+
+struct CliqueStageStats {
+    since: Instant,
+    batches_received: usize,
+    shreds_received: usize,
+    shreds_skipped: usize,
+    shreds_outbound: usize,
+    transmit_plan_ns: u64,
+    transmit_attempts: usize,
+    transmit_errors: usize,
+    transmit_execute_ns: u64,
+}
+
+impl CliqueStageStats {
+
+    fn new() -> Self {
+        Self {
+            since: Instant::now(),
+            batches_received: 0usize,
+            shreds_received: 0usize,
+            shreds_skipped: 0usize,
+            shreds_outbound: 0usize,
+            transmit_plan_ns: 0,
+            transmit_attempts: 0usize,
+            transmit_errors: 0usize,
+            transmit_execute_ns: 0,
+        }
+    }
+
+    fn maybe_submit(&mut self) {
+        if self.since.elapsed() <= METRICS_SUBMIT_CADENCE {
+            return;
+        }
+        datapoint_info!(
+            "clique_stage",
+            ("batches_received", self.batches_received, i64),
+            ("shreds_received", self.shreds_received, i64),
+            ("shreds_skipped", self.shreds_skipped, i64),
+            ("shreds_outbound", self.shreds_outbound, i64),
+            ("transmit_plan_ns", self.transmit_plan_ns, i64),
+            ("transmit_attempts", self.transmit_attempts, i64),
+            ("transmit_errors", self.transmit_errors, i64),
+            ("transmit_execute_ns", self.transmit_execute_ns, i64),
+        );
+        *self = Self::new();
+    }
+}
+
+#[derive(NetworkBehaviour)]
+struct SolanaCliqueBehaviour {
+    gossipsub: gossipsub::Gossipsub,
+    identify: identify::Behaviour,
+    ping: ping::Behaviour,
+}
+
+pub struct CliqueStage {
+    gossip_thread_hdl: JoinHandle<()>,
+    outbound_thread_hdl: JoinHandle<()>,
+}
+
+impl CliqueStage {
+    pub fn new<S>(
+        bind_addr: SocketAddr,
+        bootstrap_peers: Arc<Vec<SocketAddr>>,
+        clique_outbound_receiver: Receiver<Vec</*shred:*/ Vec<u8>>>,
+        clique_outbound_sockets: Arc<Vec<UdpSocket>>,
+        exit: Arc<AtomicBool>,
+        identity_keypair: Arc<solana_sdk::signature::Keypair>,
+        shred_inbound: SocketAddr,
+        socket_addr_space: SocketAddrSpace,
+        slot_query: S
+    ) -> Self where S: 'static + Send + Fn() -> u64 {
+        let mut stats = CliqueStageStats::new();
+        
+        let boot_slot = slot_query();
+        let clique_status = Arc::new(RwLock::new(HashMap::new()));
+        
+        let gossip_clique_status = clique_status.clone();
+        let gossip_exit= exit.clone();
+        let gossip_identity_keypair = identity_keypair.clone();
+        let gossip_shred_inbound = shred_inbound.clone();
+        let gossip_thread_hdl = Builder::new()
+            .name("solCliqueGossip".to_string())
+            .spawn(move || {
+
+                // Derive peer id from solana keypair
+                let copy = gossip_identity_keypair.secret().as_bytes().clone();
+                let secret_key = identity::ed25519::SecretKey::from_bytes(copy)
+                    .expect("CliqueStage solana_keypair is ed25519 compatible");
+                let local_key = identity::Keypair::Ed25519(secret_key.into());
+                let local_peer_id = PeerId::from(local_key.public());
+                debug!("identity {:?}", local_key.public());
+
+                // Set up an encrypted DNS-enabled TCP Transport over the Mplex protocol.
+                let transport = tcp::async_io::Transport::default()
+                    .upgrade(core::upgrade::Version::V1)
+                    .authenticate(
+                        noise::NoiseAuthenticated::xx(&local_key.clone())
+                            .expect("CliqueStage noise authentication available"),
+                    )
+                    .multiplex(yamux::YamuxConfig::default())
+                    .boxed();
+
+
+                // To content-address message, we can take the hash of message and use it as an ID.
+                let message_id_fn = |message: &gossipsub::GossipsubMessage| {
+                    let mut s = DefaultHasher::new();
+                    message.data.hash(&mut s);
+                    let hash = s.finish().to_string();
+                    gossipsub::MessageId::from(hash)
+                };
+
+                // Set a custom gossipsub configuration
+                let gossipsub_config = gossipsub::GossipsubConfigBuilder::default()
+                    .heartbeat_interval(GOSSIP_HEARTBEAT_CADENCE) // This is set to aid debugging by not cluttering the log space
+                    .validation_mode(gossipsub::ValidationMode::Strict) // This sets the kind of message validation. The default is Strict (enforce message signing)
+                    .message_id_fn(message_id_fn) 
+                    .build()
+                    .expect("CliqueStage valid gossipsub_config");
+
+                // Build a gossipsub network behaviour
+                let mut gossipsub = gossipsub::Gossipsub::new(
+                    gossipsub::MessageAuthenticity::Signed(local_key.clone()),
+                    gossipsub_config,
+                )
+                .expect("CliqueStage correct gossipsub_config");
+
+                // Create a Gossipsub topic
+                let topic: gossipsub::Topic<gossipsub::topic::Sha256Hash> =
+                    gossipsub::Topic::new("solana-clique");
+
+                // subscribes to our topic
+                gossipsub
+                    .subscribe(&topic)
+                    .expect("CliqueStage subscribe to topic");
+
+                // Build an identify network behaviour
+                let identify = identify::Behaviour::new(identify::Config::new(
+                    format!("/solana/{}", solana_version::version!()),
+                    local_key.public(),
+                ));
+
+                // Build a ping network behaviour
+                let ping = ping::Behaviour::new(ping::Config::new());
+
+                // Create a Swarm to manage peers and events from behaviours
+                let mut swarm = {
+                    let behaviour = SolanaCliqueBehaviour {
+                        gossipsub,
+                        identify,
+                        ping,
+                    };
+                    Swarm::with_async_std_executor(transport, behaviour, local_peer_id)
+                };
+
+                // Reach out to other nodes if specified
+                for peer in bootstrap_peers.iter() {
+                    let addr = socket_addr_to_multi_addr(*peer);
+                    swarm.dial(addr.clone()).expect("dial succeeds");
+                    debug!("dial peer: {peer:?} {addr:?}");
+                }
+
+                // Listen on all interfaces
+                let listen_addr = socket_addr_to_multi_addr(bind_addr);
+                swarm.listen_on(listen_addr.clone()).expect(&format!("listen  succeeds {bind_addr:?} {listen_addr:?}"));
+
+                // build a minimal context to execute libp2p's futures
+                let waker = noop_waker();
+                let mut cx = Context::from_waker(&waker);
+                let mut last_heartbeat = Instant::now();
+                
+                loop {
+                    if gossip_exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+
+                    // broadcast heartbeat message to announce membership of the clique
+                    if last_heartbeat.elapsed() > GOSSIP_HEARTBEAT_CADENCE {   
+                        let current_slot = slot_query();
+                        let message = CliqueHeartbeatMessage {
+                            boot_slot, current_slot, shred_inbound: gossip_shred_inbound
+                        };
+
+                        debug!("publish: {message:?}");
+                        if let Err(e) = swarm
+                            .behaviour_mut().gossipsub
+                            .publish(topic.clone(), bincode::serialize(&CliqueGossipMessage::Heartbeat(message)).unwrap()) {
+                            debug!("publish error: {e:?}");
+                        }
+
+                        last_heartbeat = Instant::now();    
+                    }
+
+                    if let Poll::Ready(Some(inbound)) = swarm.poll_next(&mut cx) {
+                        match inbound {
+                            SwarmEvent::NewListenAddr { address, .. } => {
+                                debug!("listen on {address:?}");
+                            }
+                            SwarmEvent::Behaviour(SolanaCliqueBehaviourEvent::Identify(event)) => {
+                                debug!("identify: {event:?}");
+                            }
+                            SwarmEvent::Behaviour(SolanaCliqueBehaviourEvent::Gossipsub(event)) => {
+                                match event {
+                                    gossipsub::GossipsubEvent::Message {
+                                        propagation_source,
+                                        message_id,
+                                        message,
+                                    } => {
+                                        if let Ok(message) = bincode::deserialize::<CliqueGossipMessage>(&message.data.as_slice()) {
+                                            let peer_pk = peer_id_to_solana_pubkey(propagation_source);
+                                            debug!("gossipsub: inbound peer={} id={:?} message={:?}", peer_pk.to_string(), message_id, message);
+
+                                            match message {
+                                                CliqueGossipMessage::Heartbeat(message) => {
+                                                    gossip_clique_status.write().unwrap().insert(peer_pk, message);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    gossipsub::GossipsubEvent::Subscribed { peer_id, topic } => {
+                                        let peer_pk = peer_id_to_solana_pubkey(peer_id);
+                                        debug!("gossipsub: peer={} subscribed topic={}", peer_pk, topic)
+                                    }
+                                    gossipsub::GossipsubEvent::Unsubscribed { peer_id, topic } => {
+                                        let peer_pk = peer_id_to_solana_pubkey(peer_id);
+                                        debug!("gossipsub: peer={} unsubscribed topic={}", peer_pk, topic)
+                                    }
+                                    gossipsub::GossipsubEvent::GossipsubNotSupported { peer_id } => {
+                                        let peer_pk = peer_id_to_solana_pubkey(peer_id);
+                                        debug!("gossipsub: peer={} unsupported", peer_pk)
+                                    }
+                                }
+                            }
+
+                            SwarmEvent::Behaviour(SolanaCliqueBehaviourEvent::Ping(event)) => {
+                                match event {
+                                    ping::Event {
+                                        peer,
+                                        result: Result::Ok(ping::Success::Ping { rtt }),
+                                    } => {
+                                        debug!(
+                                            "ping: rtt to {} is {} ms",
+                                            peer.to_base58(),
+                                            rtt.as_millis()
+                                        );
+                                    }
+                                    ping::Event {
+                                        peer,
+                                        result: Result::Ok(ping::Success::Pong),
+                                    } => {
+                                        debug!("ping: pong from {}", peer.to_base58());
+                                    }
+                                    ping::Event {
+                                        peer,
+                                        result: Result::Err(ping::Failure::Timeout),
+                                    } => {
+                                        debug!("ping: timeout to {}", peer.to_base58());
+                                    }
+                                    ping::Event {
+                                        peer,
+                                        result: Result::Err(ping::Failure::Unsupported),
+                                    } => {
+                                        debug!(
+                                            "ping: {} does not support ping protocol",
+                                            peer.to_base58()
+                                        );
+                                    }
+                                    ping::Event {
+                                        peer,
+                                        result: Result::Err(ping::Failure::Other { error }),
+                                    } => {
+                                        debug!(
+                                            "ping: failure with {}: {error}",
+                                            peer.to_base58()
+                                        );
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        let mut hasher_reset_ts = Instant::now();
+        let mut shreds_received = LruCache::<ShredId, _>::new(DEFAULT_LRU_SIZE);
+        let mut packet_hasher = PacketHasher::default();
+        let num_threads = get_thread_count().min(8).max(clique_outbound_sockets.len());
+        let thread_pool = ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|i| format!("solCliqueRetransmitSender{i:02}"))
+            .build()
+            .unwrap();
+
+        let outbound_thread_hdl = Builder::new()
+            .name("solCliqueOutboundReceiver".to_string())
+            .spawn(move || {
+                while !exit.load(Ordering::Relaxed) {                
+                    if let Ok(mut shreds) = clique_outbound_receiver.recv_timeout(RECV_TIMEOUT) {
+                        // collect more shreds that might be available to be transmitted
+                        shreds.extend(clique_outbound_receiver.try_iter().flatten());
+                        stats.batches_received += 1;
+                        stats.shreds_received += shreds.len();
+                        
+                        maybe_reset_shreds_received_cache(
+                            &mut shreds_received,
+                            &mut packet_hasher,
+                            &mut hasher_reset_ts,
+                        );
+
+                        // Skip shreds that have already been transmitted to this clique
+                        // Collect all information needed for turbine to determine where to send a shred
+                        let mut transmit_plan = Measure::start("clique_transmit_plan");
+                        let shreds: Vec<_> = shreds
+                            .into_iter()
+                            .filter_map(|shred| {
+                                let key = get_shred_id(&shred)?;
+                                if should_skip_retransmit(key, &shred, &mut shreds_received, &packet_hasher) {
+                                    stats.shreds_skipped += 1;
+                                    None
+                                } else {
+                                    Some((key, shred))
+                                }
+                            })
+                            .into_group_map_by(|(key, _)| key.slot())
+                            // TODO: evaluate if par_iter can help here, we might send shreds for multiple slots at once
+                            .into_iter()
+                            .filter_map(|(slot, shreds)| {
+                                let active_clique_members: Vec<_> = clique_status
+                                    .read()
+                                    .unwrap()
+                                    .iter()
+                                    .filter(|(_, m)| m.boot_slot + CLIQUE_WARMUP_SLOTS < slot && slot < m.current_slot + CLIQUE_TIMEOUT_SLOTS )
+                                    .map(|(pk,m)|(*pk, m.shred_inbound))
+                                    .chain(once((identity_keypair.pubkey(), shred_inbound)))
+                                    .collect();
+                                let cluster_nodes = Arc::new(ClusterNodes::<CliqueStage>::new(identity_keypair.pubkey(), &active_clique_members));
+                            
+                                Some(izip!(shreds, repeat(cluster_nodes)))
+                            })
+                            .flatten()
+                            .collect();
+                        transmit_plan.stop();
+                        stats.transmit_plan_ns += transmit_plan.as_ns();
+                        stats.shreds_outbound += shreds.len();
+
+                        // transmit shreds over UDP (in parallel if needed) while aggregating stats
+                        let mut transmit_execute = Measure::start("clique_transmit_execute");
+                        let init_stats = (0,0);
+                        let merge_stats = |t1: (usize, usize), t2: (usize,usize)| (t1.0 + t2.0, t1.1 + t2.1);
+                        let transmit_stats = if shreds.len() < PAR_ITER_MIN_NUM_SHREDS {
+                            shreds
+                                .into_iter()
+                                .enumerate()
+                                .map(|(index, ((key, shred), cluster_nodes))| {
+                                    let (_root_distance, transmit_attempts, transmit_errors) = retransmit_shred(
+                                        &key,
+                                        &shred,
+                                        &cluster_nodes,
+                                        &socket_addr_space,
+                                        &clique_outbound_sockets[index % clique_outbound_sockets.len()],
+                                    );
+                                    (transmit_attempts, transmit_errors)
+                                })
+                                .fold(init_stats,merge_stats)
+                        } else {
+                            thread_pool.install(|| {
+                                shreds
+                                    .into_par_iter()
+                                    .map(|((key, shred), cluster_nodes)| {
+                                        let index = thread_pool.current_thread_index().unwrap();
+                                        let (_root_distance, transmit_attempts, transmit_errors) = retransmit_shred(
+                                            &key,
+                                            &shred,
+                                            &cluster_nodes,
+                                            &socket_addr_space,
+                                            &clique_outbound_sockets[index % clique_outbound_sockets.len()],
+                                        );
+                                        (transmit_attempts, transmit_errors)
+                                        
+                                    })
+                                    .fold(|| init_stats, merge_stats)
+                                    .reduce(|| init_stats, merge_stats)
+                            })
+                        };
+                        transmit_execute.stop();
+                        stats.transmit_execute_ns += transmit_execute.as_ns();
+                        stats.transmit_attempts += transmit_stats.0;
+                        stats.transmit_errors += transmit_stats.1;
+                    } // END - recv
+                    stats.maybe_submit();
+                } // END - while
+            }) // END - spawn
+            .unwrap();
+
+        Self { gossip_thread_hdl, outbound_thread_hdl }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.outbound_thread_hdl.join()?;
+        self.gossip_thread_hdl.join()?;
+        Ok(())
+    }
+}
+
+// copied and adapted from retransmit_stage.rs
+fn retransmit_shred(
+    key: &ShredId,
+    shred: &[u8],
+    cluster_nodes: &ClusterNodes<CliqueStage>,
+    socket_addr_space: &SocketAddrSpace,
+    socket: &UdpSocket,
+) -> (/*root_distance:*/ usize, /*num_nodes:*/ usize, /*num_failed*/ usize) {
+    let (root_distance, addrs) =
+        cluster_nodes.get_retransmit_addrs( key, DATA_PLANE_FANOUT);
+
+    let addrs: Vec<_> = addrs
+        .into_iter()
+        .filter(|addr| LegacyContactInfo::is_valid_address(addr, socket_addr_space))
+        .collect();
+    
+    let num_failed = match multi_target_send(socket, shred, &addrs) {
+        Ok(()) => 0,
+        Err(SendPktsError::IoError(ioerr, num_failed)) => {
+            error!(
+                "retransmit_to multi_target_send error: {:?}, {}/{} packets failed",
+                ioerr,
+                num_failed,
+                addrs.len(),
+            );
+            num_failed
+        }
+    };
+
+    (root_distance, addrs.len(), num_failed)
+}
+
+// libp2p adds a few extra bytes in the beginning to tag peer ids
+fn peer_id_to_solana_pubkey(
+    peer_id: PeerId,
+) -> Pubkey {
+    let bytes = peer_id.to_bytes();
+    let split_index = bytes.len() - 32;
+    let pk_bytes = <&[u8; 32]>::try_from(&bytes[split_index..]).unwrap();
+    Pubkey::new_from_array(*pk_bytes)
+}
+
+fn socket_addr_to_multi_addr(
+    socket: SocketAddr
+) -> Multiaddr {
+    let mut addr = Multiaddr::from(socket.ip());
+    addr.push(Protocol::Tcp(socket.port()));
+    return addr
+}

--- a/core/src/cluster_nodes.rs
+++ b/core/src/cluster_nodes.rs
@@ -1,3 +1,7 @@
+use std::cmp::min;
+
+use crate::clique_stage::CliqueStage;
+
 use {
     crate::{broadcast_stage::BroadcastStage, retransmit_stage::RetransmitStage},
     itertools::Itertools,
@@ -132,7 +136,8 @@ impl<T> ClusterNodes<T> {
 
 impl ClusterNodes<BroadcastStage> {
     pub fn new(cluster_info: &ClusterInfo, stakes: &HashMap<Pubkey, u64>) -> Self {
-        new_cluster_nodes(cluster_info, stakes)
+        let nodes = collect_stake_sorted_nodes(cluster_info, stakes);
+        new_cluster_nodes(cluster_info.id(), nodes)
     }
 
     pub(crate) fn get_broadcast_peer(&self, shred: &ShredId) -> Option<&ContactInfo> {
@@ -143,7 +148,153 @@ impl ClusterNodes<BroadcastStage> {
     }
 }
 
+impl ClusterNodes<CliqueStage> {
+    pub fn new(self_pubkey: Pubkey, clique_nodes: &Vec<(Pubkey, SocketAddr)>) -> Self {
+        // all nodes in clique have the same stake weight
+        let stake = 1;
+
+        let nodes = clique_nodes
+            .iter()
+            .map(|(pk, addr)| {
+                let sparse_contact_info = ContactInfo {
+                    id: *pk,
+                    tvu: *addr,
+                    ..Default::default()
+                };
+                Node {
+                    node: NodeId::from(sparse_contact_info),
+                    stake,
+                }
+            })
+            .sorted_by_key(|node| Reverse(node.pubkey()))
+            // Since sorted_by_key is stable, in case of duplicates, this
+            // will keep nodes with contact-info.
+            .dedup_by(|a, b| a.pubkey() == b.pubkey())
+            .collect();
+
+        new_cluster_nodes(self_pubkey, nodes)
+    }
+
+    pub(crate) fn get_retransmit_addrs(
+        &self,
+        shred: &ShredId,
+        fanout: usize,
+    ) -> (/*root_distance:*/ usize, Vec<SocketAddr>) {
+        let RetransmitPeers {
+            root_distance,
+            neighbors,
+            children,
+            addrs,
+            frwds: _
+        } = self.get_retransmit_peers(shred, fanout);
+
+        // Neigbors can include duplicates
+        let peers = neighbors
+            .iter()
+            .chain(children.iter())
+            .filter_map(|n| n.contact_info())
+            .filter(|node| addrs.get(&node.tvu) == Some(&node.id))
+            .map(|node| node.tvu)
+            .dedup()
+            .collect();
+        (root_distance, peers)
+    }
+
+    // this creates a graph that has the following structure & root distances for F=fanout:
+    // 0: [], there are no nodes with root distance 0
+    // 1: [0..F), all nodes w/ root distance 1 are linked as neighbours
+    // 2: [[F..2F),...,[F^2..F^2+F)], all nodes w/ root distance >=2 are linked to their parent [0..F)
+    // all neighbour and parent-child links are bi-directional
+    // RetransmitPeers.neighbors contains neigbor <-> neigbor and child->parent 
+    // RetransmitPeers.children contains parent -> child
+    pub fn get_retransmit_peers(&self, shred: &ShredId, fanout: usize) -> RetransmitPeers {
+        let shred_seed = shred.seed(&Pubkey::default());
+        let weighted_shuffle = self.weighted_shuffle.clone();
+
+        let mut addrs = HashMap::<SocketAddr, Pubkey>::with_capacity(self.nodes.len());
+        let frwds = Default::default();
+        let mut rng = ChaChaRng::from_seed(shred_seed);
+        let nodes: Vec<_> = weighted_shuffle
+            .shuffle(&mut rng)
+            .map(|index| &self.nodes[index])
+            .inspect(|node| {
+                if let Some(node) = node.contact_info() {
+                    addrs.entry(node.tvu).or_insert(node.id);
+                }
+            })
+            .collect();
+
+        if nodes.len() == 0 {
+            return RetransmitPeers {
+                root_distance: 0usize,
+                neighbors: Default::default(),
+                children: Default::default(),
+                addrs,
+                frwds
+            };
+        }
+
+        let self_index = nodes
+            .iter()
+            .position(|node| node.pubkey() == self.pubkey)
+            .unwrap();
+
+        // children can lie outside of the array range, but skip & take handle that case
+        let children_start = (self_index + 1) * fanout;
+        let children = nodes
+            .iter()
+            .skip(children_start)
+            .take(fanout)
+            .map(|n| *n)
+            .collect();
+
+        // calculate root_distance and level_end_index
+        let mut root_distance = 1;
+        while root_distance < 10 {
+            let next_level_start_index = (1..root_distance+1).map(|rd| fanout.pow(rd)).sum();
+            if self_index < next_level_start_index {
+                break;
+            }
+            root_distance += 1;
+        }
+
+        let neighbors = if root_distance == 1 {
+            // top level has no parent relationship, only neighbors
+            // ensure neighbor indexes don't lie outside of array range
+            let l1_len = min(nodes.len(), fanout);
+            let left_neighbor = min(l1_len - 1, self_index + fanout - 1) % fanout;
+            let right_neighbor = (self_index + 1) % l1_len;
+            if l1_len == 1 {
+                // if there's only one node, it doesn't have any neighbors
+                vec![]
+            } else if l1_len == 2 {
+                // left_neighbor == right_neighbor, so we only need to return it once
+                vec![nodes[left_neighbor]]
+            } else {
+                vec![nodes[left_neighbor], nodes[right_neighbor]]
+            }
+        } else {
+            // lower levels only have their parent as neighbor, no range checks needed
+            let parent_index = (self_index / fanout) - 1;
+            vec![nodes[parent_index]]
+        };
+
+        RetransmitPeers {
+            root_distance: root_distance as usize,
+            neighbors,
+            children,
+            addrs,
+            frwds,
+        }
+    }
+}
+
 impl ClusterNodes<RetransmitStage> {
+    pub fn new(cluster_info: &ClusterInfo, stakes: &HashMap<Pubkey, u64>) -> Self {
+        let nodes = collect_stake_sorted_nodes(cluster_info, stakes);
+        new_cluster_nodes(cluster_info.id(), nodes)
+    }
+    
     pub(crate) fn get_retransmit_addrs(
         &self,
         slot_leader: &Pubkey,
@@ -272,12 +423,8 @@ impl ClusterNodes<RetransmitStage> {
     }
 }
 
-pub fn new_cluster_nodes<T: 'static>(
-    cluster_info: &ClusterInfo,
-    stakes: &HashMap<Pubkey, u64>,
-) -> ClusterNodes<T> {
-    let self_pubkey = cluster_info.id();
-    let nodes = get_nodes(cluster_info, stakes);
+// nodes is expected to be sorted by (stake, pubkey) in descending order
+pub fn new_cluster_nodes<T: 'static>(self_pubkey: Pubkey, nodes: Vec<Node>) -> ClusterNodes<T> {
     let index: HashMap<_, _> = nodes
         .iter()
         .enumerate()
@@ -300,8 +447,12 @@ pub fn new_cluster_nodes<T: 'static>(
 
 // All staked nodes + other known tvu-peers + the node itself;
 // sorted by (stake, pubkey) in descending order.
-fn get_nodes(cluster_info: &ClusterInfo, stakes: &HashMap<Pubkey, u64>) -> Vec<Node> {
+fn collect_stake_sorted_nodes(
+    cluster_info: &ClusterInfo,
+    stakes: &HashMap<Pubkey, u64>,
+) -> Vec<Node> {
     let self_pubkey = cluster_info.id();
+
     // The local node itself.
     std::iter::once({
         let stake = stakes.get(&self_pubkey).copied().unwrap_or_default();
@@ -417,10 +568,9 @@ impl<T: 'static> ClusterNodesCache<T> {
             }
             inc_new_counter_info!("cluster_nodes-unknown_epoch_staked_nodes_root", 1);
         }
-        let nodes = Arc::new(new_cluster_nodes::<T>(
-            cluster_info,
-            &epoch_staked_nodes.unwrap_or_default(),
-        ));
+        let nodes =
+            collect_stake_sorted_nodes(cluster_info, &epoch_staked_nodes.unwrap_or_default());
+        let nodes = Arc::new(new_cluster_nodes::<T>(cluster_info.id(), nodes));
         *entry = Some((Instant::now(), Arc::clone(&nodes)));
         nodes
     }
@@ -539,6 +689,8 @@ fn check_feature_activation(feature: &Pubkey, shred_slot: Slot, root_bank: &Bank
 
 #[cfg(test)]
 mod tests {
+    use solana_ledger::shred::layout::get_shred_id;
+
     use super::*;
 
     #[test]
@@ -547,7 +699,7 @@ mod tests {
         let (nodes, stakes, cluster_info) = make_test_cluster(&mut rng, 1_000, None);
         // ClusterInfo::tvu_peers excludes the node itself.
         assert_eq!(cluster_info.tvu_peers().len(), nodes.len() - 1);
-        let cluster_nodes = new_cluster_nodes::<RetransmitStage>(&cluster_info, &stakes);
+        let cluster_nodes = ClusterNodes::<RetransmitStage>::new(&cluster_info, &stakes);
         // All nodes with contact-info should be in the index.
         // Staked nodes with no contact-info should be included.
         assert!(cluster_nodes.nodes.len() > nodes.len());
@@ -680,5 +832,73 @@ mod tests {
             let mut retransmit_peers = get_retransmit_peers(/*fanout:*/ 3, k, &index);
             assert_eq!(retransmit_peers.next(), None);
         }
+    }
+
+
+    fn generate_cluster_nodes(num: usize) -> Vec<ClusterNodes<CliqueStage>> {
+        let keys: Vec<Pubkey> = (0..num).map(|i| Pubkey::find_program_address(&[&[(i / 256) as u8, (i % 256) as u8]], &Pubkey::default()).0).collect();
+        let addrs: Vec<SocketAddr> = (0..num).map(|i| format!("1.2.3.4:{}", 13000+i).parse().unwrap()).collect();
+        let clique = (0..num).map(|i| (keys[i], addrs[i])).collect();
+        return (0..num).map(|i| ClusterNodes::<CliqueStage>::new(keys[i], &clique)).collect();
+    }
+
+    #[test]
+    fn test_get_clique_peers_solo() {
+        let single_node_cluster = generate_cluster_nodes(1);
+        let shred_id = get_shred_id(&(0..83).collect::<Vec<u8>>().as_slice()).unwrap();
+        let peers = single_node_cluster[0].get_retransmit_peers(&shred_id, 2);
+        assert_eq!(peers.root_distance, 1);
+        assert_eq!(peers.neighbors.len(), 0);
+        assert_eq!(peers.children.len(), 0);
+    }
+
+    #[test]
+    fn test_get_clique_peers_neighbors() {
+        let dual_node_cluster = generate_cluster_nodes(4);
+        let shred_id = get_shred_id(&(0..83).collect::<Vec<u8>>().as_slice()).unwrap();
+
+        // L1: [0: n=1,3] [1: n=0,2] [2: n=1,3] [3: n=0,2]
+        for peers in dual_node_cluster.iter().map(|ns| ns.get_retransmit_peers(&shred_id, 4)) {
+            assert_eq!(peers.root_distance, 1);
+            assert_eq!(peers.neighbors.len(), 2);
+            assert_eq!(peers.children.len(), 0);
+        }
+    }
+
+
+    #[test]
+    fn test_get_clique_peers_children() {
+        let deep_cluster = generate_cluster_nodes(13);
+        let shred_id = get_shred_id(&(0..83).collect::<Vec<u8>>().as_slice()).unwrap();
+        let peers: Vec<_> = deep_cluster.iter().map(|ns| ns.get_retransmit_peers(&shred_id, 3)).collect();
+
+        // L1: [0: n=1,2 c=4,5,6] [1: n=0,2 c=7,8,9] [2: n=0,1 c=10,11,12]
+        let l1: Vec<_> = peers.iter().filter(|ps| ps.root_distance == 1).collect();
+        assert_eq!(l1.len(), 3);
+        for peers in l1 {
+            assert_eq!(peers.neighbors.len(), 2);
+            assert_eq!(peers.children.len(), 3);
+        }
+
+        // L2: [4: n=0 c=12], [5: n=0], ..., [11: n=2]
+        let l2: Vec<_> = peers.iter().filter(|ps| ps.root_distance == 2).sorted_by_key(|ps| -1 * ps.children.len() as i64).collect();
+        assert_eq!(l2.len(), 9);
+        for (i, peers) in l2.iter().enumerate() {
+            assert_eq!(peers.neighbors.len(), 1);
+            if i == 0 {
+                assert_eq!(peers.children.len(), 1);
+             } else {
+                assert_eq!(peers.children.len(), 0);
+             }
+        }
+
+        // L3: [12: n=4]
+        let l3: Vec<_> = peers.iter().filter(|ps| ps.root_distance == 3).collect();
+        assert_eq!(l3.len(), 1);
+        for peers in l3 {
+            assert_eq!(peers.neighbors.len(), 1);
+            assert_eq!(peers.children.len(), 0);
+        }
+
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ancestor_hashes_service;
 pub mod banking_stage;
 pub mod broadcast_stage;
 pub mod cache_block_meta_service;
+pub mod clique_stage;
 pub mod cluster_info_vote_listener;
 pub mod cluster_nodes;
 pub mod cluster_slot_state_verifier;

--- a/core/src/retransmit_stage.rs
+++ b/core/src/retransmit_stage.rs
@@ -124,7 +124,7 @@ impl RetransmitStats {
 type ShredFilter = LruCache<ShredId, Vec<u64>>;
 
 // Returns true if shred is already received and should skip retransmit.
-fn should_skip_retransmit(
+pub(crate) fn should_skip_retransmit(
     key: ShredId,
     shred: &[u8],
     shreds_received: &mut ShredFilter,
@@ -149,7 +149,7 @@ fn should_skip_retransmit(
     }
 }
 
-fn maybe_reset_shreds_received_cache(
+pub(crate) fn maybe_reset_shreds_received_cache(
     shreds_received: &mut ShredFilter,
     packet_hasher: &mut PacketHasher,
     hasher_reset_ts: &mut Instant,

--- a/core/src/sigverify_shreds.rs
+++ b/core/src/sigverify_shreds.rs
@@ -32,6 +32,7 @@ pub(crate) fn spawn_shred_sigverify(
     shred_fetch_receiver: Receiver<PacketBatch>,
     retransmit_sender: Sender<Vec</*shred:*/ Vec<u8>>>,
     verified_sender: Sender<Vec<PacketBatch>>,
+    clique_outbound_sender: Sender<Vec</*shred:*/ Vec<u8>>>,
     turbine_disabled: Arc<AtomicBool>,
 ) -> JoinHandle<()> {
     let recycler_cache = RecyclerCache::warmed();
@@ -47,6 +48,7 @@ pub(crate) fn spawn_shred_sigverify(
                 &shred_fetch_receiver,
                 &retransmit_sender,
                 &verified_sender,
+                &clique_outbound_sender,
                 &turbine_disabled,
                 &mut stats,
             ) {
@@ -68,6 +70,7 @@ fn run_shred_sigverify(
     shred_fetch_receiver: &Receiver<PacketBatch>,
     retransmit_sender: &Sender<Vec</*shred:*/ Vec<u8>>>,
     verified_sender: &Sender<Vec<PacketBatch>>,
+    clique_outbound_sender: &Sender<Vec</*shred:*/ Vec<u8>>>,
     turbine_disabled: &AtomicBool,
     stats: &mut ShredSigVerifyStats,
 ) -> Result<(), Error> {
@@ -98,8 +101,9 @@ fn run_shred_sigverify(
         .collect();
     stats.num_retransmit_shreds += shreds.len();
     if !turbine_disabled.load(Ordering::Relaxed) {
-        retransmit_sender.send(shreds)?;
+        retransmit_sender.send(shreds.clone())?;
         verified_sender.send(packets)?;
+        clique_outbound_sender.send(shreds)?;
     }
     stats.elapsed_micros += now.elapsed().as_micros() as u64;
     Ok(())

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -176,6 +176,8 @@ pub struct ValidatorConfig {
     pub ledger_column_options: LedgerColumnOptions,
     pub runtime_config: RuntimeConfig,
     pub replay_slots_concurrently: bool,
+    pub clique_addr: Option<SocketAddr>,
+    pub clique_peers: Arc<Vec<SocketAddr>>,
 }
 
 impl Default for ValidatorConfig {
@@ -238,6 +240,8 @@ impl Default for ValidatorConfig {
             ledger_column_options: LedgerColumnOptions::default(),
             runtime_config: RuntimeConfig::default(),
             replay_slots_concurrently: false,
+            clique_addr: None,
+            clique_peers: Default::default(),
         }
     }
 }
@@ -941,6 +945,7 @@ impl Validator {
             TvuSockets {
                 repair: node.sockets.repair,
                 retransmit: node.sockets.retransmit_sockets,
+                clique: node.sockets.clique_sockets,
                 fetch: node.sockets.tvu,
                 forwards: node.sockets.tvu_forwards,
                 ancestor_hashes_requests: node.sockets.ancestor_hashes_requests,
@@ -981,6 +986,8 @@ impl Validator {
             config.runtime_config.log_messages_bytes_limit,
             &connection_cache,
             &prioritization_fee_cache,
+            config.clique_addr,
+            config.clique_peers.clone(),
         )?;
 
         let tpu = Tpu::new(

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2795,6 +2795,7 @@ pub struct Sockets {
     pub broadcast: Vec<UdpSocket>,
     pub repair: UdpSocket,
     pub retransmit_sockets: Vec<UdpSocket>,
+    pub clique_sockets: Vec<UdpSocket>,
     pub serve_repair: UdpSocket,
     pub ancestor_hashes_requests: UdpSocket,
     pub tpu_quic: UdpSocket,
@@ -2833,6 +2834,7 @@ impl Node {
             SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), rpc_pubsub_port);
 
         let broadcast = vec![UdpSocket::bind("0.0.0.0:0").unwrap()];
+        let clique_sockets = vec![UdpSocket::bind("0.0.0.0:0").unwrap()];
         let retransmit_socket = UdpSocket::bind("0.0.0.0:0").unwrap();
         let serve_repair = UdpSocket::bind("127.0.0.1:0").unwrap();
         let ancestor_hashes_requests = UdpSocket::bind("0.0.0.0:0").unwrap();
@@ -2865,6 +2867,7 @@ impl Node {
                 broadcast,
                 repair,
                 retransmit_sockets: vec![retransmit_socket],
+                clique_sockets,
                 serve_repair,
                 ancestor_hashes_requests,
                 tpu_quic,
@@ -2909,6 +2912,7 @@ impl Node {
             bind_two_in_range_with_offset(bind_ip_addr, port_range, QUIC_PORT_OFFSET).unwrap();
         let (tpu_vote_port, tpu_vote) = Self::bind(bind_ip_addr, port_range);
         let (_, retransmit_socket) = Self::bind(bind_ip_addr, port_range);
+        let (_, clique_socket) = Self::bind(bind_ip_addr, port_range);
         let (repair_port, repair) = Self::bind(bind_ip_addr, port_range);
         let (serve_repair_port, serve_repair) = Self::bind(bind_ip_addr, port_range);
         let (_, broadcast) = Self::bind(bind_ip_addr, port_range);
@@ -2947,6 +2951,7 @@ impl Node {
                 broadcast: vec![broadcast],
                 repair,
                 retransmit_sockets: vec![retransmit_socket],
+                clique_sockets: vec![clique_socket],
                 serve_repair,
                 ancestor_hashes_requests,
                 tpu_quic,
@@ -3002,6 +3007,9 @@ impl Node {
         let (_, broadcast) =
             multi_bind_in_range(bind_ip_addr, port_range, 4).expect("broadcast multi_bind");
 
+        let (_, clique_sockets) =
+            multi_bind_in_range(bind_ip_addr, port_range, 8).expect("clique multi_bind");
+
         let (_, ancestor_hashes_requests) = Self::bind(bind_ip_addr, port_range);
 
         let info = ContactInfo {
@@ -3033,6 +3041,7 @@ impl Node {
                 broadcast,
                 repair,
                 retransmit_sockets,
+                clique_sockets,
                 serve_repair,
                 ip_echo: Some(ip_echo),
                 ancestor_hashes_requests,
@@ -3224,6 +3233,7 @@ mod tests {
                     broadcast: vec![],
                     repair: UdpSocket::bind("0.0.0.0:0").unwrap(),
                     retransmit_sockets: vec![],
+                    clique_sockets: vec![],
                     serve_repair: UdpSocket::bind("0.0.0.0:0").unwrap(),
                     ancestor_hashes_requests: UdpSocket::bind("0.0.0.0:0").unwrap(),
                     tpu_quic: UdpSocket::bind("0.0.0.0:0").unwrap(),

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -191,8 +191,8 @@ pub enum ShredType {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(into = "u8", try_from = "u8")]
 enum ShredVariant {
-    LegacyCode, // 0b0101_1010
-    LegacyData, // 0b1010_0101
+    LegacyCode, // 0b0101_1010 // 0x5A
+    LegacyData, // 0b1010_0101 // 0xA5
     // proof_size is the number of proof entries in the merkle tree branch.
     MerkleCode(/*proof_size:*/ u8), // 0b0100_????
     MerkleData(/*proof_size:*/ u8), // 0b1000_????

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -64,6 +64,8 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         ledger_column_options: config.ledger_column_options.clone(),
         runtime_config: config.runtime_config.clone(),
         replay_slots_concurrently: config.replay_slots_concurrently,
+        clique_addr: config.clique_addr,
+        clique_peers: config.clique_peers.clone()
     }
 }
 

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -29,7 +29,7 @@ pub struct UdpSocketPair {
 pub type PortRange = (u16, u16);
 
 pub const VALIDATOR_PORT_RANGE: PortRange = (8000, 10_000);
-pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 13; // VALIDATOR_PORT_RANGE must be at least this wide
+pub const MINIMUM_VALIDATOR_PORT_RANGE_WIDTH: u16 = 14; // VALIDATOR_PORT_RANGE must be at least this wide
 
 pub(crate) const HEADER_LENGTH: usize = 4;
 pub(crate) const IP_ECHO_SERVER_RESPONSE_LENGTH: usize = HEADER_LENGTH + 23;

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -362,6 +362,30 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                        [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]"),
         )
         .arg(
+            Arg::with_name("clique_port")
+                .long("clique-port")
+                .value_name("PORT")
+                .takes_value(true)
+                .help("Clique port number for the validator"),
+        )
+        .arg(
+            Arg::with_name("clique_bind_address")
+                .long("clique-bind-address")
+                .value_name("HOST")
+                .takes_value(true)
+                .validator(solana_net_utils::is_host)
+                .help("IP address to bind the Clique port [default: --bind_address]"),
+        )
+        .arg(
+            Arg::with_name("clique_peers")
+                .long("clique-peers")
+                .value_name("HOST:PORT")
+                .multiple(true)
+                .takes_value(true)
+                .validator(solana_net_utils::is_host_port)
+                .help("Clique bootstrap peers")
+        )
+        .arg(
             Arg::with_name("tpu_host_addr")
                 .long("tpu-host-addr")
                 .value_name("HOST:PORT")


### PR DESCRIPTION
PoC for initial clique service implementation.

This provides a new stage in TVU that forwards shreds to a local clique.
Discovery is handled through manual dialing a rendezvous node.
Hearbeats are exchanged through libp2p gossipsub.
Shreds are forwarded via UDP to validator TVUs.
Distribution is according to random per shred graphs with undirected edges, which ensures a limited edge count per node (fanout+2) to limit excess bandwidth.
Bankless non-validator nodes are supported: [example test-client](https://github.com/mschneider/test-client-libp2p-solana/blob/main/src/main.rs)

