### PR TITLE
rpc ipv6 on v1.18

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,7 +1,7 @@
 //! The `net_utils` module assists with networking
 #![allow(clippy::arithmetic_side_effects)]
 
-use std::net::Ipv6Addr;
+use std::net::{AddrParseError, Ipv6Addr};
 use std::str::FromStr;
 use {
     crossbeam_channel::unbounded,
@@ -344,30 +344,8 @@ pub fn parse_port_range(port_range: &str) -> Option<PortRange> {
 }
 
 pub fn parse_host(host: &str) -> Result<IpAddr, String> {
-
-    println!("SKIP CHECK: HOST={}", host);
-    if true {
-        return Ok(SocketAddr::from_str(&format!("{}:0", host)).expect("valid IP").ip());
-    }
-
-    // First, check if the host syntax is valid. This check is needed because addresses
-    // such as `("localhost:1234", 0)` will resolve to IPs on some networks.
-    let parsed_url = Url::parse(&format!("http://{host}")).map_err(|e| e.to_string())?;
-    if parsed_url.port().is_some() {
-        return Err(format!("Expected port in URL: {host}"));
-    }
-
-    // Next, check to see if it resolves to an IP address
-    let ips: Vec<_> = (host, 0)
-        .to_socket_addrs()
-        .map_err(|err| err.to_string())?
-        .map(|socket_address| socket_address.ip())
-        .collect();
-    if ips.is_empty() {
-        Err(format!("Unable to resolve host: {host}"))
-    } else {
-        Ok(ips[0])
-    }
+    IpAddr::from_str(host)
+        .map_err(|err| format!("Unable to parse host bind address <{}>: {}", host, err))
 }
 
 pub fn is_host(string: String) -> Result<(), String> {

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -1,5 +1,8 @@
 //! The `net_utils` module assists with networking
 #![allow(clippy::arithmetic_side_effects)]
+
+use std::net::Ipv6Addr;
+use std::str::FromStr;
 use {
     crossbeam_channel::unbounded,
     log::*,
@@ -341,6 +344,12 @@ pub fn parse_port_range(port_range: &str) -> Option<PortRange> {
 }
 
 pub fn parse_host(host: &str) -> Result<IpAddr, String> {
+
+    println!("SKIP CHECK: HOST={}", host);
+    if true {
+        return Ok(SocketAddr::from_str(&format!("{}:0", host)).expect("valid IP").ip());
+    }
+
     // First, check if the host syntax is valid. This check is needed because addresses
     // such as `("localhost:1234", 0)` will resolve to IPs on some networks.
     let parsed_url = Url::parse(&format!("http://{host}")).map_err(|e| e.to_string())?;

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -343,6 +343,11 @@ pub fn parse_port_range(port_range: &str) -> Option<PortRange> {
     Some((start_port, end_port))
 }
 
+/// note: this is a very naive simplification done to support IPv6 bindings
+///
+/// conversely it does not do hostname reverse lookup
+///
+/// recommended values to use are `127.0.0.1`, `0.0.0.0`, or `::1` or `::` for binding
 pub fn parse_host(host: &str) -> Result<IpAddr, String> {
     IpAddr::from_str(host)
         .map_err(|err| format!("Unable to parse host bind address <{}>: {}", host, err))


### PR DESCRIPTION
#### Problem
RPC node could not bind to IPv6 address

#### Summary of Changes
change the host check to allow IPv6 (and IPv4) binding on CLI

